### PR TITLE
feat: add team list of specific performance api

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from .views import generation, performance, session, team
 
 urlpatterns = [
+    # Generation
     path(
         "generations/",
         generation.GenerationListCreateAPIView.as_view(),
@@ -12,6 +13,8 @@ urlpatterns = [
         generation.GenerationRetrieveUpdateDestroyAPIView.as_view(),
         name="generation-retrieve_update_destroy",
     ),
+
+    # Performance
     path(
         "performances/",
         performance.PerformanceListCreateAPIView.as_view(),
@@ -23,6 +26,13 @@ urlpatterns = [
         name="performance-retrieve_update_destroy",
     ),
     path(
+        "performances/<int:pk>/teams/",
+        performance.PerformanceTeamListAPIView.as_view(),
+        name="performance-team",
+    ),
+
+    # Session
+    path(
         "sessions/",
         session.SessionListCreateAPIView.as_view(),
         name="session-list_create",
@@ -32,6 +42,8 @@ urlpatterns = [
         session.SessionRetrieveUpdateDestroyAPIView.as_view(),
         name="session-retrieve_update_destroy",
     ),
+
+    # Team
     path("teams/", team.TeamListCreateAPIView.as_view(), name="team-list_create"),
     path(
         "teams/<int:pk>/",

--- a/core/views/performance.py
+++ b/core/views/performance.py
@@ -1,6 +1,8 @@
-from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView, ListAPIView
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 
+from core.models.team import Team
+from core.serializers.team import TeamSerializer
 from core.models.performance import Performance
 from core.serializers.performance import PerformanceSerializer
 from core.views.filters import PerformanceFilter
@@ -25,3 +27,13 @@ class PerformanceRetrieveUpdateDestroyAPIView(RetrieveUpdateDestroyAPIView):
         if self.request.method == "GET":
             return [IsAuthenticated()]
         return [IsAdminUser()]
+
+
+class PerformanceTeamListAPIView(ListAPIView):
+    serializer_class = TeamSerializer
+
+    def get_queryset(self):
+        return Team.objects.filter(performance__id=self.kwargs["pk"])
+
+    def get_permissions(self):
+        return [IsAuthenticated()]


### PR DESCRIPTION
이전에는 `Team` 목록을 받을 때 `Performance` 구분 없이 모든 데이터를 반환했습니다.
이제 특정 공연에 대해서만 팀 목록을 반환하는 API를 추가했습니다.